### PR TITLE
New command-line options and a self.minor variable

### DIFF
--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -35,12 +35,14 @@ if __name__ == "__main__":
 	args = parser.parse_args()
 
 
-	# define key_signature
+	# define key_signature and mode
 
 	if args.key in minor_to_major_map:
 		key_signature = minor_to_major_map[args.key]
+		minor = True
 	else:
 		key_signature = args.key
+		minor = False
 
 	
 	# check notes of each instrument (if applicable) to catch any out-of-normal-range notes
@@ -50,6 +52,7 @@ if __name__ == "__main__":
 		params =
 		{
 		  'opts': args,
+		  'minor': minor,
 		}
 	)
 	

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
 	parser.add_argument('filename')
 	parser.add_argument('-c', '--check', help='Check if any instrument notes fall out of the expected range (if applicable).', default=False, action='store_true') # check notes if any instrument notes fall out of expected range
 	parser.add_argument('-k', '--key', help=f'Specify the key signature for the piece. Options are: c (default), g, d, a, e, b, f, bb, eb, ab, db, gb, cb, fs, cs. You can also pass in a minor key: {", ".join(minor_to_major_map.keys())}.', default=None) # specify key signature for piece (default is key of C Major)
+	parser.add_argument('-t', '--title', metavar = 'str', help='Set piece title' )
 	
 	args = parser.parse_args()
 

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -33,11 +33,24 @@ if __name__ == "__main__":
 	parser.add_argument('-k', '--key', help=f'Specify the key signature for the piece. Options are: c (default), g, d, a, e, b, f, bb, eb, ab, db, gb, cb, fs, cs. You can also pass in a minor key: {", ".join(minor_to_major_map.keys())}.', default=None) # specify key signature for piece (default is key of C Major)
 	
 	args = parser.parse_args()
-	
+
+
+	# define key_signature
+
 	if args.key in minor_to_major_map:
-		args.key = minor_to_major_map[args.key]
+		key_signature = minor_to_major_map[args.key]
+	else:
+		key_signature = args.key
+
 	
 	# check notes of each instrument (if applicable) to catch any out-of-normal-range notes
-	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=args.key)
+
+	converter = MMP_MusicXML_Converter (
+		key_signature = key_signature,
+		params =
+		{
+		  'opts': args,
+		}
+	)
 	
 	converter.convert_file(args.filename)

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
 	parser.add_argument('-c', '--check', help='Check if any instrument notes fall out of the expected range (if applicable).', default=False, action='store_true') # check notes if any instrument notes fall out of expected range
 	parser.add_argument('-k', '--key', help=f'Specify the key signature for the piece. Options are: c (default), g, d, a, e, b, f, bb, eb, ab, db, gb, cb, fs, cs. You can also pass in a minor key: {", ".join(minor_to_major_map.keys())}.', default=None) # specify key signature for piece (default is key of C Major)
 	parser.add_argument('-t', '--title', metavar = 'str', help='Set piece title' )
+	parser.add_argument('-n', '--names', metavar = 'str', help='Select semicolon-separated list of instrument names' )
 	
 	args = parser.parse_args()
 

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -207,6 +207,7 @@ class MMP_MusicXML_Converter:
 		logging.basicConfig(level=logging.DEBUG)
 
 		self.opts = params['opts']
+		self.minor = params['minor']
 
 		if self.opts.check:
 			logging.debug("note checking is on")
@@ -215,6 +216,8 @@ class MMP_MusicXML_Converter:
 		if key_signature:
 			if key_signature in self.FIFTHS:
 				logging.debug(f"adjusting notes per key signature: {key_signature}")
+				if self.minor:
+					logging.debug( 'minor mode [%s]' % self.opts.key )
 				self.NOTE_ADJUSTER = KeySignatureNoteFinder()
 				self.SPECIFIED_KEY_SIGNATURE = key_signature
 			else:

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -203,10 +203,12 @@ class MMP_MusicXML_Converter:
 	
 	SPECIFIED_KEY_SIGNATURE = None
 	
-	def __init__(self, check_notes=False, key_signature=None):
+	def __init__ ( self, key_signature = None, params = None ):
 		logging.basicConfig(level=logging.DEBUG)
-		
-		if check_notes:
+
+		self.opts = params['opts']
+
+		if self.opts.check:
 			logging.debug("note checking is on")
 			self.NOTE_CHECKER = NoteChecker()
 			

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -644,10 +644,17 @@ class MMP_MusicXML_Converter:
 		# create the general tree structure, then fill in accordingly
 		score_partwise = ET.Element('score-partwise')
 
+
 		# title of piece
-		# TODO: allow user to set name of piece via arg
+
 		movement_title = ET.SubElement(score_partwise, 'movement-title')
-		movement_title.text = "title of piece goes here"
+
+		if self.opts.title:
+			movement_title.text = self.opts.title
+			logging.debug ( 'title: ' + movement_title.text )
+		else:
+			movement_title.text = "title of piece goes here"
+
 
 		# list of the instrument parts 
 		part_list = ET.SubElement(score_partwise, 'part-list')

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -656,7 +656,17 @@ class MMP_MusicXML_Converter:
 			movement_title.text = "title of piece goes here"
 
 
+		# instrument track names
+
+		if self.opts.names:
+			names = self.opts.names.split ( ';' )
+			logging.debug ( 'tracks: ' + '|'.join ( names ) )
+		else:
+			names = self.INSTRUMENTS.union ( self.BASS_INSTRUMENTS )
+
+
 		# list of the instrument parts 
+
 		part_list = ET.SubElement(score_partwise, 'part-list')
 
 		# then go through each instrument in the mmp file and add them to part-list 
@@ -666,7 +676,7 @@ class MMP_MusicXML_Converter:
 			isMuted = el.attrib['muted'] == "1"
 			inst_count = str(instrument_counter)
 			
-			if (name in self.INSTRUMENTS or name in self.BASS_INSTRUMENTS) and not isMuted:
+			if ( name in names ) and not isMuted:
 				# need to also check if there are notes for this instrument. if it's an empty track, skip it
 				if el.find("pattern") is None:
 					continue
@@ -723,7 +733,7 @@ class MMP_MusicXML_Converter:
 			name = el.attrib['name']
 			is_muted = el.attrib['muted'] == "1"
 			
-			if (name in self.INSTRUMENTS or name in self.BASS_INSTRUMENTS) and not is_muted:
+			if ( name in names ) and not is_muted:
 				# get the pattern chunks (which hold the notes)
 				pattern_chunks = []
 				for el2 in el.iter(tag = 'pattern'):


### PR DESCRIPTION
Hello @syncopika,

I'd like to share some ideas with you in a branch I forked from your `add-specified-key-signature-support`.

First, I've added 2 command-line options:

`--title` to allow user-defined piece titles;
`--names` to allow user-defined instrument names.

And, more important to our key-signatures issue, I though it might be useful if `converter` knows by means of a `self.minor` boolean when the key signature it's working from is derived from a minor key command-line option.

I started learning Python yesterday, so please forgive any Perlish line.

Best,