### PR TITLE
Define key signatures without overwriting the --key command-line option

### DIFF
--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
 	parser.add_argument('filename')
 	parser.add_argument('-c', '--check', help='Check if any instrument notes fall out of the expected range (if applicable).', default=False, action='store_true') # check notes if any instrument notes fall out of expected range
 	parser.add_argument('-k', '--key', help=f'Specify the key signature for the piece. Options are: c (default), g, d, a, e, b, f, bb, eb, ab, db, gb, cb, fs, cs. You can also pass in a minor key: {", ".join(minor_to_major_map.keys())}.', default=None) # specify key signature for piece (default is key of C Major)
+	parser.add_argument('-m', '--master', metavar='i', help='Set master pitch')
 	
 	args = parser.parse_args()
 	

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 		minor = None
 	
 	# check notes of each instrument (if applicable) to catch any out-of-normal-range notes
-	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=major,
+	converter = MMP_MusicXML_Converter(key_signature=major,
 		params =
 		{
 		  'opts': args,

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
 	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=major,
 		params =
 		{
+		  'opts': args,
 		  'minor': minor,
 		})
 	

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -35,9 +35,13 @@ if __name__ == "__main__":
 	args = parser.parse_args()
 	
 	if args.key in minor_to_major_map:
-		args.key = minor_to_major_map[args.key]
+		minor = args.key
+		major = minor_to_major_map[minor]
+	else:
+		major = args.key
+		minor = None
 	
 	# check notes of each instrument (if applicable) to catch any out-of-normal-range notes
-	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=args.key)
+	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=major)
 	
 	converter.convert_file(args.filename)

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
 	parser.add_argument('-k', '--key', help=f'Specify the key signature for the piece. Options are: c (default), g, d, a, e, b, f, bb, eb, ab, db, gb, cb, fs, cs. You can also pass in a minor key: {", ".join(minor_to_major_map.keys())}.', default=None) # specify key signature for piece (default is key of C Major)
 	parser.add_argument('-m', '--master', metavar='i', help='Set master pitch')
 	parser.add_argument('-t', '--title', metavar='str', help='Set piece title')
+	parser.add_argument('-i', '--instruments', metavar='str', help='Select instrument tracks using the plus sign (+) as list separator: violin+cello')
 	
 	args = parser.parse_args()
 	

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
 	parser.add_argument('-c', '--check', help='Check if any instrument notes fall out of the expected range (if applicable).', default=False, action='store_true') # check notes if any instrument notes fall out of expected range
 	parser.add_argument('-k', '--key', help=f'Specify the key signature for the piece. Options are: c (default), g, d, a, e, b, f, bb, eb, ab, db, gb, cb, fs, cs. You can also pass in a minor key: {", ".join(minor_to_major_map.keys())}.', default=None) # specify key signature for piece (default is key of C Major)
 	parser.add_argument('-m', '--master', metavar='i', help='Set master pitch')
+	parser.add_argument('-t', '--title', metavar='str', help='Set piece title')
 	
 	args = parser.parse_args()
 	

--- a/convert-mmp.py
+++ b/convert-mmp.py
@@ -42,6 +42,10 @@ if __name__ == "__main__":
 		minor = None
 	
 	# check notes of each instrument (if applicable) to catch any out-of-normal-range notes
-	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=major)
+	converter = MMP_MusicXML_Converter(check_notes=args.check, key_signature=major,
+		params =
+		{
+		  'minor': minor,
+		})
 	
 	converter.convert_file(args.filename)

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -203,9 +203,14 @@ class MMP_MusicXML_Converter:
 	
 	SPECIFIED_KEY_SIGNATURE = None
 	
-	def __init__(self, check_notes=False, key_signature=None):
+	minor = None
+
+	def __init__(self, check_notes=False, key_signature=None, params=None):
 		logging.basicConfig(level=logging.DEBUG)
 		
+		if params:
+			if 'minor' in params: self.minor = params['minor']
+
 		if check_notes:
 			logging.debug("note checking is on")
 			self.NOTE_CHECKER = NoteChecker()
@@ -213,6 +218,7 @@ class MMP_MusicXML_Converter:
 		if key_signature:
 			if key_signature in self.FIFTHS:
 				logging.debug(f"adjusting notes per key signature: {key_signature}")
+				if self.minor: logging.debug(f"minor mode [{self.minor}]")
 				self.NOTE_ADJUSTER = KeySignatureNoteFinder()
 				self.SPECIFIED_KEY_SIGNATURE = key_signature
 			else:

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -203,12 +203,14 @@ class MMP_MusicXML_Converter:
 	
 	SPECIFIED_KEY_SIGNATURE = None
 	
+	opts = None
 	minor = None
 
 	def __init__(self, check_notes=False, key_signature=None, params=None):
 		logging.basicConfig(level=logging.DEBUG)
 		
 		if params:
+			if 'opts' in params: self.opts = params['opts']
 			if 'minor' in params: self.minor = params['minor']
 
 		if check_notes:

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -61,6 +61,9 @@ class MMP_MusicXML_Converter:
 		"tubular bells",
 		"xylophone",
 		"marimba",
+		"treble", "soprano", "alto", "tenor",
+		"upper",
+		"right", "rechte" "droite", "destra",
 	])
 	
 	# these instruments will get bass clefs in the resulting xml
@@ -78,6 +81,8 @@ class MMP_MusicXML_Converter:
 		"timpani",
 		"bass clarinet",
 		"contrabass clarinet",
+		"lower",
+		"left", "linke", "gauche", "sinistra",
 	])
 	
 	# https://en.wikipedia.org/wiki/General_MIDI

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -206,14 +206,14 @@ class MMP_MusicXML_Converter:
 	opts = None
 	minor = None
 
-	def __init__(self, check_notes=False, key_signature=None, params=None):
+	def __init__(self, key_signature=None, params=None):
 		logging.basicConfig(level=logging.DEBUG)
 		
 		if params:
 			if 'opts' in params: self.opts = params['opts']
 			if 'minor' in params: self.minor = params['minor']
 
-		if check_notes:
+		if self.opts and self.opts.check:
 			logging.debug("note checking is on")
 			self.NOTE_CHECKER = NoteChecker()
 			

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -652,9 +652,13 @@ class MMP_MusicXML_Converter:
 		score_partwise = ET.Element('score-partwise')
 
 		# title of piece
-		# TODO: allow user to set name of piece via arg
 		movement_title = ET.SubElement(score_partwise, 'movement-title')
-		movement_title.text = "title of piece goes here"
+
+		if self.opts and self.opts.title:
+			movement_title.text = self.opts.title
+			logging.debug (f"title: {movement_title.text}")
+		else:
+			movement_title.text = "title of piece goes here"
 
 		# list of the instrument parts 
 		part_list = ET.SubElement(score_partwise, 'part-list')

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -628,6 +628,10 @@ class MMP_MusicXML_Converter:
 		# get the master pitch. if it's not 0, we can alter the notes accordingly. 
 		MASTER_PITCH = int(root.find('head').attrib['masterpitch'])
 
+		if self.opts and self.opts.master:
+			MASTER_PITCH = int(self.opts.master)
+			logging.debug(f"MASTER_PITCH: {str(MASTER_PITCH)}")
+
 		# LMMS measure length variable needs to be based on the time signature numerator 
 		# a quarter note is always length 48 
 		self.LMMS_MEASURE_LENGTH = self.NOTE_TYPE["quarter"] * int(self.TIME_SIGNATURE_NUMERATOR)

--- a/mmp_to_musicxml/converter.py
+++ b/mmp_to_musicxml/converter.py
@@ -660,6 +660,13 @@ class MMP_MusicXML_Converter:
 		else:
 			movement_title.text = "title of piece goes here"
 
+		# instrument track names
+		if self.opts and self.opts.instruments:
+			names = self.opts.instruments.split('+')
+			logging.debug (f"tracks: {'|'.join(names)}")
+		else:
+			names = self.INSTRUMENTS.union(self.BASS_INSTRUMENTS)
+
 		# list of the instrument parts 
 		part_list = ET.SubElement(score_partwise, 'part-list')
 
@@ -670,7 +677,7 @@ class MMP_MusicXML_Converter:
 			isMuted = el.attrib['muted'] == "1"
 			inst_count = str(instrument_counter)
 			
-			if (name in self.INSTRUMENTS or name in self.BASS_INSTRUMENTS) and not isMuted:
+			if (name in names) and not isMuted:
 				# need to also check if there are notes for this instrument. if it's an empty track, skip it
 				if el.find("pattern") is None:
 					continue
@@ -727,7 +734,7 @@ class MMP_MusicXML_Converter:
 			name = el.attrib['name']
 			is_muted = el.attrib['muted'] == "1"
 			
-			if (name in self.INSTRUMENTS or name in self.BASS_INSTRUMENTS) and not is_muted:
+			if (name in names) and not is_muted:
 				# get the pattern chunks (which hold the notes)
 				pattern_chunks = []
 				for el2 in el.iter(tag = 'pattern'):


### PR DESCRIPTION
Hello @syncopika,

I've formatted my edits as per your comments, and made the code work even if `self.opts` is undefined. Also, in addition to --title, and --names, I've added a --master command-line option to override LMMS master pitch.

Best,
n.